### PR TITLE
Add docs for dfoptim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - run: npm install codecov -g
       - run: npm run-script test
       - run: npm run-script lint
+      - run: npm run-script docs
       - uses: codecov/codecov-action@v1
         with:
           files: coverage/*.json

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+name: docs
+
+on:
+  push:
+    branches: [main, master, reside-296]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - run: npm install
+      - run: npm run-script docs
+      - name: Publish
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
+          force_orphan: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: docs
 
 on:
   push:
-    branches: [main, master, reside-296]
+    branches: [main, master]
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ lib
 .nyc_output
 coverage
 *.tgz
+docs

--- a/README.md
+++ b/README.md
@@ -1,27 +1,18 @@
 ## Derivative-free optimisation in javascript
 
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
-[![build status](https://github.com/reside-ic/dfoptim/workflows/ci/badge.svg)](https://github.com/reside-ic/dfoptim/actions)
-[![codecov.io](https://codecov.io/github/reside-ic/dfoptim/coverage.svg?branch=master)](https://codecov.io/github/reside-ic/dfoptim?branch=master)
+[![build-and-test](https://github.com/reside-ic/dfoptim/actions/workflows/ci.yml/badge.svg)](https://github.com/reside-ic/dfoptim/actions/workflows/ci.yml)
+[![codecov.io](https://codecov.io/github/reside-ic/dfoptim/coverage.svg?branch=main)](https://codecov.io/github/reside-ic/dfoptim?branch=main)
 
 Very simple optimisation, using the [Simplex (Nelder-Mead) method](https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method)
 
 We provide two interfaces. In the first, you can dfoptim a function in a single go:
 
 ```
-const point = dfoptim.fitSimplex(target, start, control, maxIterations);
+const point = dfoptim.fitSimplex(target, start);
 ```
 
-which will look for the minimum of the vector-valued function `target`, starting from location `start`. The `control` object is described below and affects how the optimisation initialises and terminates, and the `maxIterations` is a per-dimension number of iterations (e.g., for a problem with 10 dimensions we will take at most `10 * maxIterations` steps before giving up).
-
-The return value will be an object with fields:
-
-* `converged`: indicates if we have successfully converged (bool)
-* `data`: see below
-* `evaluations`: the number of times that `target` was called
-* `iterations`: the number of iterations of the algorithm (always greater than `evaluations`)
-* `location`: the best location (input to `target`)
-* `value`: the value of the target function at `location`
+which will look for the minimum of the vector-valued function `target`, starting from location `start`.
 
 Running the optimisation may take a while, and no information can be retrieved while it runs, so we also provide a more stateful interface. The function above can be implemented as:
 
@@ -37,31 +28,7 @@ Where
 
 * `opt` is our optimiser. At this point, it has done basic set up (creating the first simplex) but not taken any steps
 * The `step()` method advances the algorithm one step, which will take one or two evaluations of the target function and may or may not find a better point than our current best. It returns `true` if we have converged.
-* The `result()` method returns the object described above.
-
-Sometimes, it is useful to get additional information out of the target function and store it alongside the solution. For example, if fitting a model to data you might end up with a sum-of-squares error used for target fitting, but the model values themselves are of interest. For linear regression we might do this by returning a closure that could be evaluated at any `x` position:
-
-```
-const xObserved = [0, 1, 2, 3, 4];
-const yObserved = [0.64, 2.41, 4.29, 6.62, 8.31]
-function target(theta) {
-    const c = theta[0]; // intercept
-    const m = theta[1]; // slope
-    var tot = 0;
-    for (var i = 0; i < xObserved.length; ++i) {
-        tot += (c + m * xObserved[i] - yObserved[i])**2;
-    }
-    return {value: tot, data: (x) => x.map(el => c + m * el)};
-}
-```
-
-This can be passed through to `fitSimplex` or `Simplex` above, and the `data` element of the result will contain the predictor function at the best point. (Do not fit linear regressions with this package - you can do that faster and more accurately with many other methods.)
-
-There are a few control parameters that can be passed via an object as the third argument to `fitSimplex` or `Simplex`
-
-* `deltaNonZero`: a multiplicatative scaling factor for non-zero initial parameter points (displacing `x` to `x * (1 + deltaNonZero)`)
-* `deltaZero`: an additive for zero initial points (replacing `x` of zero with `deltaZero`)
-* `tolerance`: A small number, indicating the "tolerance" of the algorithm - the smaller this is the more we try and refine the solution. We stop when the difference between the and worst point in the simplex is smaller than this value (absolutely or relatively) **and** where the largest size of any axis of the simplex drops below this value.
+* The `result()` method returns information about the best point.
 
 ## Example
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "ts-jest": "^28.0.0",
                 "ts-loader": "^9.3.0",
                 "tslint": "^5.20.1",
+                "typedoc": "^0.23.1",
                 "typescript": "^4.2.0",
                 "webpack": "^5.72.1",
                 "webpack-cli": "^4.9.2"
@@ -4527,6 +4528,12 @@
                 "node": ">=6"
             }
         },
+        "node_modules/jsonc-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+            "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+            "dev": true
+        },
         "node_modules/kind-of": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -4605,6 +4612,12 @@
                 "node": ">=10"
             }
         },
+        "node_modules/lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true
+        },
         "node_modules/make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -4633,6 +4646,18 @@
             "dev": true,
             "dependencies": {
                 "tmpl": "1.0.5"
+            }
+        },
+        "node_modules/marked": {
+            "version": "4.0.17",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
+            "integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==",
+            "dev": true,
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 12"
             }
         },
         "node_modules/merge-stream": {
@@ -5135,6 +5160,17 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/shiki": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+            "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+            "dev": true,
+            "dependencies": {
+                "jsonc-parser": "^3.0.0",
+                "vscode-oniguruma": "^1.6.1",
+                "vscode-textmate": "5.2.0"
             }
         },
         "node_modules/signal-exit": {
@@ -5771,6 +5807,48 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/typedoc": {
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.1.tgz",
+            "integrity": "sha512-6Lb8E+RTEUPzdPUNugQQTOQYccq0iSfZgZ875fzSynByJWC7RbKNwLIx0Osv8pcJyiByy3jH/wdZR0tajuijLQ==",
+            "dev": true,
+            "dependencies": {
+                "lunr": "^2.3.9",
+                "marked": "^4.0.16",
+                "minimatch": "^5.1.0",
+                "shiki": "^0.10.1"
+            },
+            "bin": {
+                "typedoc": "bin/typedoc"
+            },
+            "engines": {
+                "node": ">= 14.14"
+            },
+            "peerDependencies": {
+                "typescript": "4.6.x || 4.7.x"
+            }
+        },
+        "node_modules/typedoc/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/typedoc/node_modules/minimatch": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+            "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/typescript": {
             "version": "4.7.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
@@ -5806,6 +5884,18 @@
             "engines": {
                 "node": ">=10.12.0"
             }
+        },
+        "node_modules/vscode-oniguruma": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+            "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+            "dev": true
+        },
+        "node_modules/vscode-textmate": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+            "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+            "dev": true
         },
         "node_modules/walker": {
             "version": "1.0.8",
@@ -9570,6 +9660,12 @@
             "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
             "dev": true
         },
+        "jsonc-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+            "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+            "dev": true
+        },
         "kind-of": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -9630,6 +9726,12 @@
                 "yallist": "^4.0.0"
             }
         },
+        "lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true
+        },
         "make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -9653,6 +9755,12 @@
             "requires": {
                 "tmpl": "1.0.5"
             }
+        },
+        "marked": {
+            "version": "4.0.17",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
+            "integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==",
+            "dev": true
         },
         "merge-stream": {
             "version": "2.0.0",
@@ -10027,6 +10135,17 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true
+        },
+        "shiki": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+            "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+            "dev": true,
+            "requires": {
+                "jsonc-parser": "^3.0.0",
+                "vscode-oniguruma": "^1.6.1",
+                "vscode-textmate": "5.2.0"
+            }
         },
         "signal-exit": {
             "version": "3.0.7",
@@ -10469,6 +10588,38 @@
             "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
             "dev": true
         },
+        "typedoc": {
+            "version": "0.23.1",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.1.tgz",
+            "integrity": "sha512-6Lb8E+RTEUPzdPUNugQQTOQYccq0iSfZgZ875fzSynByJWC7RbKNwLIx0Osv8pcJyiByy3jH/wdZR0tajuijLQ==",
+            "dev": true,
+            "requires": {
+                "lunr": "^2.3.9",
+                "marked": "^4.0.16",
+                "minimatch": "^5.1.0",
+                "shiki": "^0.10.1"
+            },
+            "dependencies": {
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+                    "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                }
+            }
+        },
         "typescript": {
             "version": "4.7.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
@@ -10494,6 +10645,18 @@
                 "@types/istanbul-lib-coverage": "^2.0.1",
                 "convert-source-map": "^1.6.0"
             }
+        },
+        "vscode-oniguruma": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+            "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+            "dev": true
+        },
+        "vscode-textmate": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+            "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+            "dev": true
         },
         "walker": {
             "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "webpack": "webpack",
         "test": "jest -c jest.config.js",
         "lint": "tslint -c tslint.json 'src/**/*.ts'",
+        "docs": "typedoc",
         "postwebpack": "cp dist/dfoptim.js example/"
     },
     "repository": {
@@ -30,6 +31,7 @@
         "ts-jest": "^28.0.0",
         "ts-loader": "^9.3.0",
         "tslint": "^5.20.1",
+        "typedoc": "^0.23.1",
         "typescript": "^4.2.0",
         "webpack": "^5.72.1",
         "webpack-cli": "^4.9.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dfoptim",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Derivative-Free Optimisation",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/control.ts
+++ b/src/control.ts
@@ -4,19 +4,22 @@
  */
 export interface SimplexControlParam {
     /** Multiplicative change for nonzero parameters when constructing
-     * the initial simplex, default is 0.05. If a starting point has a
-     * nonzero value `x` for some dimension, then the value will be
-     * perturbed to `x * (1 + deltaNonZero)` */
+     *  the initial simplex, default is 0.05. If a starting point has
+     *  a nonzero value `x` for some dimension, then the value will be
+     *  perturbed to `x * (1 + deltaNonZero)`
+     */
     deltaNonZero: number;
     /** Absolute change for zero parameters when constructing the
-     * initial simplex, default is 0.001. If a starting point has a
-     * zero value `x` for some dimension then this value will be
-     * perturbed to `deltaZero` */
+     *  initial simplex, default is 0.001. If a starting point has a
+     *  zero value `x` for some dimension then this value will be
+     *  perturbed to `deltaZero`
+     */
     deltaZero: number;
     /** Tolerance used in the convergence heuristics. Default is
-     * 1e-5. Setting this value too small is likely to result in
-     * issues with floating point arithmetic, or very slow convergence
-     * in the final steps. */
+     *  1e-5. Setting this value too small is likely to result in
+     *  issues with floating point arithmetic, or very slow
+     *  convergence in the final steps.
+     */
     tolerance: number;
 }
 

--- a/src/control.ts
+++ b/src/control.ts
@@ -1,6 +1,22 @@
+/**
+ * Control for the Simplex. Only some of these (or, indeed none of
+ * these) can be provided to {@link Simplex} or {@link fitSimplex}
+ */
 export interface SimplexControlParam {
+    /** Multiplicative change for nonzero parameters when constructing
+     * the initial simplex, default is 0.05. If a starting point has a
+     * nonzero value `x` for some dimension, then the value will be
+     * perturbed to `x * (1 + deltaNonZero)` */
     deltaNonZero: number;
+    /** Absolute change for zero parameters when constructing the
+     * initial simplex, default is 0.001. If a starting point has a
+     * zero value `x` for some dimension then this value will be
+     * perturbed to `deltaZero` */
     deltaZero: number;
+    /** Tolerance used in the convergence heuristics. Default is
+     * 1e-5. Setting this value too small is likely to result in
+     * issues with floating point arithmetic, or very slow convergence
+     * in the final steps. */
     tolerance: number;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
+export { SimplexControlParam } from "./control";
 export { Simplex, fitSimplex } from "./simplex";
+export { Result, TargetFn } from "./types";

--- a/src/simplex.ts
+++ b/src/simplex.ts
@@ -198,12 +198,14 @@ export class Simplex {
             /** Has the algorithm converged? */
             converged: this._converged,
             /** Any additional data returned by the target function,
-             *  for this point */
+             *  for this point
+             */
             data: best.data,
             /** The number of times that `target` has been called so far */
             evaluations: this._id,
             /** The number of times that {@link Simplex.step} has been
-             * called so far */
+             *  called so far
+             */
             iterations: this._iterations,
             /** The best found location */
             location: best.location,

--- a/src/simplex.ts
+++ b/src/simplex.ts
@@ -25,7 +25,7 @@ function weightedSum(w: number, v1: number[], v2: number[]) {
  *
  * @param maxIterations The maximum number of iterations, per
  * dimension, of the algorithm (calls to {@link Simplex.step |
- * `Simplex.step()`} to take. For example, if you pass `maxIterations`
+ * `Simplex.step()`}) to take. For example, if you pass `maxIterations`
  * of 200 and are solving a problem where `location.length` is 5,
  * you'll take a maximum of 1000 steps in total. If we converge before
  * hitting this number we will return early.

--- a/src/simplex.ts
+++ b/src/simplex.ts
@@ -282,9 +282,6 @@ export class Simplex {
     }
 
     private _isConverged() {
-        if (this._converged) {
-            return true;
-        }
         const tolerance = this._control.tolerance;
         const best = this._simplex[0];
         const worst = this._simplex[this._n];

--- a/src/simplex.ts
+++ b/src/simplex.ts
@@ -167,14 +167,14 @@ export class Simplex {
     /**
      * Helper function to run the algorithm until converged. This is
      * very basic and not really intended to be used - you should
-     * probably build logic around [[`Simplex.step`]] directly, or if
-     * you want a simple interface use the [[`fitSimplex`]] function.
+     * probably build logic around {@link Simplex.step} directly, or if
+     * you want a simple interface use the {@link fitSimplex} function.
      *
      * @param maxIterations The maximum number of iterations of the
-     * algorithm (calls to [[`Simplex.step`]] to take. If we converge
+     * algorithm (calls to {@link Simplex.step} to take. If we converge
      * before hitting this number we will return early.
      *
-     * @return The same object as [[`Simplex.result`]]. Note that the
+     * @return The same object as {@link Simplex.result}. Note that the
      * algorithm may not have converged, so you should check the
      * `.converged` field.
      */

--- a/src/simplex.ts
+++ b/src/simplex.ts
@@ -12,6 +12,26 @@ function weightedSum(w: number, v1: number[], v2: number[]) {
     return ret;
 }
 
+/**
+ * Run the Simplex algorithm on a target function. This is a
+ * convenience function and offers little control but a compact
+ * interface.
+ *
+ * @param target The function to be minimised
+ *
+ * @param location The initial location to start the search from
+ *
+ * @param control Control parameters, as an object
+ *
+ * @param maxIterations The maximum number of iterations, per
+ * dimension, of the algorithm (calls to {@link Simplex.step |
+ * `Simplex.step()`} to take. For example, if you pass `maxIterations`
+ * of 200 and are solving a problem where `location.length` is 5,
+ * you'll take a maximum of 1000 steps in total. If we converge before
+ * hitting this number we will return early.
+ *
+ * @returns See {@link Simplex.result | `Simplex.result`} for details
+ */
 export function fitSimplex(target: TargetFn, location: number[],
                            control: Partial<SimplexControlParam> = {},
                            maxIterations: number = 200) {
@@ -19,14 +39,39 @@ export function fitSimplex(target: TargetFn, location: number[],
     return solver.run(maxIterations * location.length);
 }
 
+/**
+ * Start, improve and interrogate an optimisation. Unlike
+ * {@link fitSimplex}, which does this in a single step, the `Simplex`
+ * class creates mutable state representing a (potentially)
+ * partially-completed optimisation process, which you are then
+ * responsible for pushing around in a loop. This means that if the
+ * optimisation is slow and you want to make it cancelleable, or if
+ * you want to report back anything about the progress of the
+ * optimsiation, you are free to do so as you'll only ever hit a
+ * method here for as long as it takes to call your `target` function
+ * a few times.
+ *
+ * @example
+ * ```typescript
+ * var banana = function(x: number, y: number, a: number, b: number) {
+ *   return (a - x)**2 + b * (y - x * x)**2;
+ * };
+ * var obj = Simplex(
+ *             (loc: number[]) => banana(loc[0], loc[1], 1, 100),
+ *             [-2, -2]);
+ * obj.result();
+ * obj.step();
+ * obj.run(10);
+ * ```
+ */
 export class Simplex {
     // Standard simplex move control. We could put these in the control,
     // but it does not seem ideal to make them tuneable really; we can
     // always move them there later.
-    public static readonly rho = 1;
-    public static readonly chi = 2;
-    public static readonly psi = -0.5;
-    public static readonly sigma = 0.5;
+    private readonly rho = 1;
+    private readonly chi = 2;
+    private readonly psi = -0.5;
+    private readonly sigma = 0.5;
 
     private _target: TargetFn;
     private _control: SimplexControlParam;
@@ -37,6 +82,13 @@ export class Simplex {
     private _id: number = 0;
     private _converged: boolean = false;
 
+    /**
+     * @param target The function to be minimised
+     *
+     * @param location The initial location to start the search from
+     *
+     * @param control Control parameters, as an object
+     */
     constructor(target: TargetFn, location: number[],
                 control: Partial<SimplexControlParam> = {}) {
         this._target = target;
@@ -57,6 +109,15 @@ export class Simplex {
         this._sort();
     }
 
+    /**
+     * Advance the optimiser one "step" of the algorithm. This will
+     * usually evaluate `target` once or twice, depending on if
+     * proposal finds an improved point or not.
+     *
+     * @return `true` if the algorithm has converged, `false`
+     * otherwise. For details about the best point so far, see
+     * {@link Simplex.result}
+     */
     public step() {
         this._iterations++;
         if (this._isConverged()) {
@@ -103,7 +164,20 @@ export class Simplex {
         return false;
     }
 
-    // not really meant to be used that much, it's a bit basic
+    /**
+     * Helper function to run the algorithm until converged. This is
+     * very basic and not really intended to be used - you should
+     * probably build logic around [[`Simplex.step`]] directly, or if
+     * you want a simple interface use the [[`fitSimplex`]] function.
+     *
+     * @param maxIterations The maximum number of iterations of the
+     * algorithm (calls to [[`Simplex.step`]] to take. If we converge
+     * before hitting this number we will return early.
+     *
+     * @return The same object as [[`Simplex.result`]]. Note that the
+     * algorithm may not have converged, so you should check the
+     * `.converged` field.
+     */
     public run(maxIterations: number) {
         if (!this._converged) {
             for (let i = 0; i < maxIterations; ++i) {
@@ -115,18 +189,37 @@ export class Simplex {
         return this.result();
     }
 
+    /**
+     * Return information about the best found point so far.
+     */
     public result() {
         const best = this._simplex[0];
         return {
+            /** Has the algorithm converged? */
             converged: this._converged,
+            /** Any additional data returned by the target function,
+             *  for this point */
             data: best.data,
+            /** The number of times that `target` has been called so far */
             evaluations: this._id,
+            /** The number of times that {@link Simplex.step} has been
+             * called so far */
             iterations: this._iterations,
+            /** The best found location */
             location: best.location,
+            /** The value of `target(location)` */
             value: best.value,
         };
     }
 
+    /**
+     * Returns an array of the points that make up the Simplex. This
+     * is primarily provided for visualisation or debugging, but it
+     * could also be used to derive alternative early exit criteria.
+     *
+     * @return An array of objects, sorted from best to worst. Each
+     * object has fields `location` and `value`.
+     */
     public simplex() {
         return this._simplex.map(
             (el) => ({location: el.location, value: el.value}));
@@ -166,27 +259,30 @@ export class Simplex {
 
     // Various "moves"
     private _reflect(point: Point, centroid: number[]) {
-        return this._point(weightedSum(Simplex.rho, centroid, point.location));
+        return this._point(weightedSum(this.rho, centroid, point.location));
     }
 
     private _expand(point: Point, centroid: number[]) {
-        return this._point(weightedSum(Simplex.chi, centroid, point.location));
+        return this._point(weightedSum(this.chi, centroid, point.location));
     }
 
     private _contractInside(point: Point, centroid: number[]) {
-        return this._point(weightedSum(Simplex.psi, centroid, point.location));
+        return this._point(weightedSum(this.psi, centroid, point.location));
     }
 
     private _contractOutside(point: Point, centroid: number[]) {
-        return this._point(weightedSum(-Simplex.psi * Simplex.rho,
+        return this._point(weightedSum(-this.psi * this.rho,
                                        centroid, point.location));
     }
 
     private _shrink(point: Point, best: number[]) {
-        return this._point(weightedSum(-Simplex.sigma, best, point.location));
+        return this._point(weightedSum(-this.sigma, best, point.location));
     }
 
     private _isConverged() {
+        if (this._converged) {
+            return true;
+        }
         const tolerance = this._control.tolerance;
         const best = this._simplex[0];
         const worst = this._simplex[this._n];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,12 @@
+/** The richer result type that can be returned by a {@link TargetFn};
+ * use this to return arbitrary additional information back alongside
+ * the optimisation.
+ */
 export interface Result {
-    data: any;  // any additional value returned by the target function
-    value: number; // the objective that we are minimising
+    /** Any additional value returned by the target function */
+    data: any;
+    /** The value of the objective function */
+    value: number;
 }
 
 export interface Point {
@@ -10,6 +16,48 @@ export interface Point {
     value: number;
 }
 
+/**
+ * The interface that a function to be minimised, passed to {@link
+ * Simplex} must satisfy. Your function must accept a vector of
+ * numbers (the point in n-dimensional space) and return either a
+ * number (the objective value) or {@link Result} (a rich result type
+ * that includes the objective value and additional information).
+ *
+ * @remarks
+ *
+ * Sometimes, it is useful to get additional information out of the
+ * target function and store it alongside the solution - this is what
+ * the {@link Result} return type is for. For example, if fitting a
+ * model to data you might end up with a sum-of-squares error used for
+ * target fitting, but the model values themselves are of
+ * interest. For linear regression we might do this by returning a
+ * closure that could be evaluated at any `x` position:
+ *
+ * ```typescript
+ * const xObserved = [0, 1, 2, 3, 4];
+ * const yObserved = [0.64, 2.41, 4.29, 6.62, 8.31]
+ * function target(theta) {
+ *     const c = theta[0]; // intercept
+ *     const m = theta[1]; // slope
+ *     var tot = 0;
+ *     for (var i = 0; i < xObserved.length; ++i) {
+ *         tot += (c + m * xObserved[i] - yObserved[i])**2;
+ *     }
+ *     return {value: tot, data: (x) => x.map(el => c + m * el)};
+ * }
+ * ```
+ *
+ * This can be passed through to {@link Simplex} above, and the `data`
+ * element of {@link Simplex.result | `Simplex.result()`} will contain
+ * the predictor function at the best point. (Do not fit linear
+ * regressions with this package - you can do that faster and more
+ * accurately with many other methods.)
+ *
+ * @param location A point in n dimensional space to evaluate
+ *
+ * @return result The value of the target function at `location`,
+ * either as a simple number or a rich {@link Result} type
+ */
 export type TargetFn = (location: number[]) => number | Result;
 
 export function checkResult(value: number | Result): Result {

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,7 @@
+{
+    "entryPoints": ["src/index.ts"],
+    "out": "docs",
+    "excludePrivate": true,
+    "excludeInternal": true,
+    "excludeNotDocumented": false
+}


### PR DESCRIPTION
Adds some basic docs for dfoptim, using typedoc - will use this as a template for pulling docs over for odin-js later (and for remembering how to use this when adding it to odin-js)

I wired up this branch to push to gh-pages, so the docs can be seen here: https://reside-ic.github.io/dfoptim/