### PR TITLE
Move error handling into package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dfoptim",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "Derivative-Free Optimisation",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/control.ts
+++ b/src/control.ts
@@ -15,6 +15,17 @@ export interface SimplexControlParam {
      *  perturbed to `deltaZero`
      */
     deltaZero: number;
+
+    /** Should we raise an error if the target function fails? If
+     *  `true` then any error in the target function is propagated out
+     *  from the solver, while if `false` then failure in the target
+     *  function is converted into a return value of `-Infinity` (this
+     *  is the default behaviour). The default behaviour is designed
+     *  for use for functions where some parameters may not make
+     *  sense, and can be used to implement bounded optimisation by
+     *  raising an error if the parameters are unsuitable.
+     */
+    errorOnFailure: boolean;
     /** Tolerance used in the convergence heuristics. Default is
      *  1e-5. Setting this value too small is likely to result in
      *  issues with floating point arithmetic, or very slow
@@ -27,11 +38,13 @@ export function simplexControl(control: Partial<SimplexControlParam> = {}) {
     const defaults = {
         deltaNonZero: 0.05,
         deltaZero: 0.001,
+        errorOnFailure: false,
         tolerance: 1e-5,
     };
     const ret = {
         deltaNonZero: withDefault(control.deltaNonZero, defaults.deltaNonZero),
         deltaZero: withDefault(control.deltaZero, defaults.deltaZero),
+        errorOnFailure: withDefault(control.errorOnFailure, defaults.errorOnFailure),
         tolerance: withDefault(control.tolerance, defaults.tolerance),
     };
     if (ret.tolerance <= 0) {

--- a/src/simplex.ts
+++ b/src/simplex.ts
@@ -12,6 +12,16 @@ function weightedSum(w: number, v1: number[], v2: number[]) {
     return ret;
 }
 
+function protect(target: TargetFn) {
+    return (location: number[]) => {
+        try {
+            return target(location);
+        } catch {
+            return Infinity;
+        }
+    };
+}
+
 /**
  * Run the Simplex algorithm on a target function. This is a
  * convenience function and offers little control but a compact
@@ -97,6 +107,12 @@ export class Simplex {
 
         this._simplex = [];
         this._simplex.push(this._point(location.slice()));
+
+        // Now that the first point has been run without error we can
+        // cope with any failure in the target function, if wanted:
+        if (!control.errorOnFailure) {
+            this._target = protect(target);
+        }
         for (let i = 0; i < this._n; ++i) {
             const p = location.slice();
             if (p[i]) {

--- a/test/simplex.test.ts
+++ b/test/simplex.test.ts
@@ -83,3 +83,30 @@ describe("can accumulate additional information", () => {
     expect(ans.data(x)).toEqual(
         x.map((el: number) => ans.location[0] + ans.location[1] * el));
 })
+
+describe("can cope with errors thrown in the target function", () => {
+    const target = (theta: number[]) => {
+        if (Math.min(...theta) < 0) {
+            throw Error("Negative values not allowed");
+        }
+        return theta.map((x: number) => x * x)
+            .reduce((a: number, b:number) => a + b, 0);
+    }
+
+    it("minimises correctly, even with errors", () => {
+        const obj = new Simplex(target, [2, 4]);
+        const result = obj.run(100);
+        expect(result.converged).toBe(true);
+        expect(result.value).toBeCloseTo(0);
+    });
+
+    it("throws if control does not prevent it", () => {
+        const obj = new Simplex(target, [2, 4], {errorOnFailure: true});
+        expect(() => obj.run(100)).toThrow("Negative values not allowed");
+    });
+
+    it("throws if starting value not valid, regardless of control", () => {
+        expect(() => new Simplex(target, [2, -4], {errorOnFailure: false}))
+            .toThrow("Negative values not allowed");
+    });
+});


### PR DESCRIPTION
This PR adds support for exception handling in the target function. For all evaluations of the target function except the first, errors are converted into `Infinity`, which the optimiser copes fine with. This is useful for bounds checking, but also for where parameters cause the integrator to fail (in the case of wodin) - these are generally poor parameters in practice