### PR TITLE
add publishing workflow and change package name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish Package to npmjs
+on:
+    release:
+        types: [published]
+    pull_request:
+        branch: npm-publish-on-release
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            id-token: write
+        steps:
+            - uses: actions/checkout@v5
+            # Setup .npmrc file to publish to npm
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "20.x"
+                  registry-url: "https://registry.npmjs.org"
+            - run: npm ci
+            - run: npm run build
+            - run: npm publish --provenance --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,5 @@
+# workflow follows example in
+# https://docs.github.com/en/actions/tutorials/publish-packages/publish-nodejs-packages#publishing-packages-to-the-npm-registry
 name: Publish Package to npmjs
 on:
     release:
@@ -17,6 +19,8 @@ jobs:
                   registry-url: "https://registry.npmjs.org"
             - run: npm ci
             - run: npm run build
+
+              # https://docs.npmjs.com/cli/v11/commands/npm-publish
             - run: npm publish --provenance --access public
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,6 @@ name: Publish Package to npmjs
 on:
     release:
         types: [published]
-    pull_request:
-        branch: npm-publish-on-release
 jobs:
     build:
         runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ Automatically publish to [NPM](https://www.npmjs.com). Assuming a version number
 * Click "Publish release"
 * This triggers the release workflow and the package will be available on NPM in a few minutes
 
-Note: This package's name on NPM is `@reside-ic/dfoptim` not `dfoptim` after migration to `reside-ic` org.
+Note: This package's name on NPM is `@reside-ic/dfoptim` not `dfoptim`.

--- a/README.md
+++ b/README.md
@@ -48,3 +48,16 @@ Then open `example/index.html` for a simple example.
 MIT © Imperial College of Science, Technology and Medicine
 
 Please note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
+
+## Publishing to NPM
+
+Automatically publish to [NPM](https://www.npmjs.com). Assuming a version number 1.0.0:
+
+* Create a release on github
+* Choose a tag -> Create a new tag: v1.0.0
+* Use this version as the description
+* Optionally describe the release
+* Click "Publish release"
+* This triggers the release workflow and the package will be available on NPM in a few minutes
+
+Note: This package's name on NPM is `@reside-ic/dfoptim` not `dfoptim` after migration to `reside-ic` org.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 
 Automatically publish to [NPM](https://www.npmjs.com). Assuming a version number 1.0.0:
 
-* Create a release on github
+* Create a [release on github](https://github.com/reside-ic/dfoptim/releases/new)
 * Choose a tag -> Create a new tag: v1.0.0
 * Use this version as the description
 * Optionally describe the release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "dfoptim",
-    "version": "0.0.6",
+    "name": "@reside-ic/dfoptim",
+    "version": "1.0.0",
     "description": "Derivative-Free Optimisation",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",


### PR DESCRIPTION
This adds automatic publish to npm on release. I ran a test workflow that triggered on this branch and it published [this](https://www.npmjs.com/package/@reside-ic/dfoptim).